### PR TITLE
Updated deployment file and GitHub Actions file (CLOSELOOP-T002)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,39 @@
+name: Docker Compose Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and Push image
+        run: |
+          docker-compose -f docker-compose.yml -f build.docker-compose.yml build
+          docker-compose -f docker-compose.yml -f build.docker-compose.yml push
+          
+      - name: Login on Azure CLI
+        uses: azure/login@v1.1
+        with:
+          creds: ${{secrets.AZURE_CREDENTIALS}}
+
+      - name: Deploy Infrastructure
+        shell: pwsh
+        env:
+          CR_PAT: ${{ secrets.CR_PAT }}        
+        run: |
+          .\infrastructure\deploy-infrastructure.ps1 -studentprefix <your abbreviation>
+          
+ 
+          


### PR DESCRIPTION

# Instructions to Fix the exercise

Modified the deployment script to have the prefix as a parameter and added the GitHub Secret environment variable instead of a local variable. To run the deployment locally, add a environment variable first that contains the GitHub Personal Access Token to pull images from the GitHub Container Registry.

```PowerShell
# Personal Access Token should be pre-configured by setup.
# $env:CR_PAT="Your Pat Here" 
./infrastructure/deploy-infrastructure.ps1
```

Also modified the GitHub Action so that it deploys the latest version of the containers to the Azure WebApp. To run the pipeline added a GitHub Secret called `AZURE_CREDENTIALS`, that contains the secrets to deploy to the resource group. Run this snippet and paste completely in the secret value.

```PowerShell
$studentprefix ="your abbreviation here"
$resourcegroupName = "fabmedical-rg-" + $studentprefix 
$rg = az group show --name $resourcegroupName | ConvertFrom-Json
az ad sp create-for-rbac --name "codetocloud-$studentprefix" --sdk-auth --role contributor --scopes $($rg.id)
```

Copy the output as value of the GitHub Secret AZURE_CREDENTIALS