### PR TITLE
GitHub Actions for publishing Docker Containers to GitHub CR (DEVWF-T007)

### DIFF
--- a/.github/workflows/fabrikam-api.yml
+++ b/.github/workflows/fabrikam-api.yml
@@ -1,10 +1,13 @@
-name: Docker
+name: Fabrikam API Build
 
 on:
   push:
     # Publish `main` as Docker `latest` image.
     branches:
       - main
+    paths:
+      - 'content-api/**'
+      - '.github/workflows/fabrikam-api.yml'      
 
     # Publish `v1.2.3` tags as releases.
     tags:
@@ -18,15 +21,9 @@ env:
   IMAGE_NAME: fabrikam-api
 
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
-  
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
-    # Ensure test job passes before pushing image.
-    
-
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
@@ -36,15 +33,14 @@ jobs:
       - name: Build image
         working-directory: content-api
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
-        
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Push image to GitHub Container Registry
         working-directory: content-api
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-      - name: Push image
         run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')

--- a/.github/workflows/fabrikam-init.yml
+++ b/.github/workflows/fabrikam-init.yml
@@ -1,10 +1,13 @@
-name: Docker
+name: Fabrikam Init Build
 
 on:
   push:
     # Publish `main` as Docker `latest` image.
     branches:
       - main
+    paths:
+      - 'content-init/**'
+      - '.github/workflows/fabrikam-init.yml'
 
     # Publish `v1.2.3` tags as releases.
     tags:
@@ -15,18 +18,12 @@ on:
 
 env:
   # TODO: Change variable to your image's name.
-  IMAGE_NAME: fabrikam-api
+  IMAGE_NAME: fabrikam-init
 
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
-  
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
-    # Ensure test job passes before pushing image.
-    
-
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
@@ -34,17 +31,16 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        working-directory: content-api
+        working-directory: content-init
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
-        
-      - name: Push image to GitHub Container Registry
-        working-directory: content-api
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
-      - name: Push image
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        working-directory: content-init
         run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')

--- a/.github/workflows/fabrikam-web.yml
+++ b/.github/workflows/fabrikam-web.yml
@@ -1,10 +1,14 @@
-name: Docker
+name: Fabrikam Web Build
 
 on:
   push:
     # Publish `main` as Docker `latest` image.
     branches:
       - main
+    paths:
+      - 'content-web/**'
+      - '.github/workflows/fabrikam-web.yml'
+      
 
     # Publish `v1.2.3` tags as releases.
     tags:
@@ -18,14 +22,9 @@ env:
   IMAGE_NAME: fabrikam-web
 
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
- 
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
-    # Ensure test job passes before pushing image.
- 
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
@@ -35,16 +34,14 @@ jobs:
       - name: Build image
         working-directory: content-web
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
-          
+
+      - name: Log into GitHub Container Registry
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
       - name: Push image to GitHub Container Registry
-        working-directory: content-web    
-
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-      - name: Push image
+        working-directory: content-web
         run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')


### PR DESCRIPTION

# Instructions to Fix the exercise

Added these 3 GitHub Actions. They trigger automatically when a new commit happens in the files associated to the build.

> One thing to Do.
>
> Create a new GitHub Secret called `CR_PAT` that contains your Personal Access Token with write:packages and read:packages permissions

Linked to [AB#1](https://dev.azure.com/odluser301755/beb01502-67be-4a8d-9de0-9ffa680f622e/_workitems/edit/1)